### PR TITLE
fix: add link to profile on mobile menu

### DIFF
--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -323,13 +323,21 @@ export default function Header({ session }: { session: Session | null }) {
               </div>
               <div className="py-6">
                 {session && (
-                  <a
-                    href="#"
-                    className="-mx-3 block rounded-lg px-3 py-2.5 text-base font-semibold leading-7 text-gray-900 hover:bg-gray-50"
-                    onClick={handleSignOut}
-                  >
-                    Sign Out
-                  </a>
+                  <>
+                    <a
+                      href="/profile"
+                      className="-mx-3 block rounded-lg px-3 py-2.5 text-base font-semibold leading-7 text-gray-900 hover:bg-gray-50"
+                    >
+                      Your Profile
+                    </a>
+                    <a
+                      href="#"
+                      className="-mx-3 block rounded-lg px-3 py-2.5 text-base font-semibold leading-7 text-gray-900 hover:bg-gray-50"
+                      onClick={handleSignOut}
+                    >
+                      Sign Out
+                    </a>
+                  </>
                 )}
                 {!session && (
                   <a


### PR DESCRIPTION
**Changes**

Behold...

<img width="535" alt="Screen Shot 2023-11-01 at 3 26 48 PM" src="https://github.com/tumavideo/yop/assets/5366725/b251f6ae-610c-4d44-a7ef-9d84062417be">

Link to your profile...!