### PR TITLE
chore: add .env.example file for configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+NEXTAUTH_URL=http://localhost:3000 # not necessary in production
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=


### PR DESCRIPTION
This commit adds a sample .env.example file for configuring environment variables in the Next.js application.

Environment variables included:
- NEXTAUTH_URL: Set to http://localhost:3000 for local development (not necessary in production).
- NEXT_PUBLIC_SUPABASE_URL: Add your Supabase URL here.
- NEXT_PUBLIC_SUPABASE_ANON_KEY: Add your Supabase anonymous key here.