### PR TITLE
fix: refresh the user session on the header after sign in

### DIFF
--- a/app/login/login-form.tsx
+++ b/app/login/login-form.tsx
@@ -38,6 +38,7 @@ export default function LoginForm({ session }: { session: Session | null }) {
     const referrer = document.referrer;
     const route = referrer.replace(origin, "");
     router.replace(route);
+    router.refresh();
   };
 
   // for the `session` to be available on first SSR render, it must be


### PR DESCRIPTION
### fix: refresh the user session on the header after sign in

<a href="https://gyazo.com/7e2704615ca2d7e9c261a61b28e2928e"><img src="https://i.gyazo.com/7e2704615ca2d7e9c261a61b28e2928e.gif" alt="Image from Gyazo" width="400"/></a>